### PR TITLE
Project accepted

### DIFF
--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -24,7 +24,8 @@ class BidsController < ApplicationController
   end
 
   def update
-    @bid.update_statuses(params[:new_status])
+    BidHelper.new(@bid, params[:new_status]).update_bid
+    #@bid.update_statuses(params[:new_status])
     if current_user.pro?
       redirect_to pro_dashboard_index_path
     else

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -24,8 +24,7 @@ class BidsController < ApplicationController
   end
 
   def update
-    BidHelper.new(@bid, params[:new_status]).update_bid
-    #@bid.update_statuses(params[:new_status])
+    BidUpdater.new(@bid, params[:new_status]).update_bid
     if current_user.pro?
       redirect_to pro_dashboard_index_path
     else

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -12,12 +12,6 @@ class Bid < ApplicationRecord
   has_many :attachments, as: :attachable
   accepts_nested_attributes_for :attachments
 
-  def update_statuses(new_status)
-    update!(status: new_status)
-    return if new_status == "withdrawn" || new_status == "rejected"
-    close_other_bids if new_status == "accepted"
-  end
-
   def close_other_bids
     bids = Bid.where(project_id: self.project_id, status: "open")
     bids.each { |b| b.update!(status: "rejected")}

--- a/app/models/bid_helper.rb
+++ b/app/models/bid_helper.rb
@@ -1,0 +1,21 @@
+class BidHelper
+  attr_reader :bid, :bid_params
+
+  def initialize(bid, bid_params)
+    @bid = bid
+    @bid_params = bid_params
+  end
+
+  def update_bid
+    @bid.update!(status: @bid_params)
+    return if @bid_params == "withdrawn" || @bid_params == "rejected"
+    if @bid_params == "accepted"
+      accept_bids
+    end
+  end
+
+  def accept_bids
+    @bid.close_other_bids
+    @bid.project.update!(status: "accepted")
+  end
+end

--- a/app/models/bid_updater.rb
+++ b/app/models/bid_updater.rb
@@ -1,4 +1,4 @@
-class BidHelper
+class BidUpdater
   attr_reader :bid, :bid_params
 
   def initialize(bid, bid_params)

--- a/spec/features/user/user_can_accept_bid_spec.rb
+++ b/spec/features/user/user_can_accept_bid_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "A user has a project and bids" do
       click_button "Accept"
       expect(current_path).to eq(project_path(bid.project))
       expect(Bid.last.status).to eq("accepted")
+      expect(Bid.last.project.status).to eq("accepted")
     end
 
     it "all other project bid statuses change to rejected" do


### PR DESCRIPTION
#### What does this PR do?

Adds a PORO BidsUpdater to update bids as they were being updated before -- except that now, when a bid is marked as "accepted", it also updates that project status to "accepted."
#### Where should the reviewer start?

app/models/bids_updater.rb and app/controller/bids_controller.rb
#### How should this be manually tested?

rspec spec/features/user/user_can_accept_bid_spec.rb
#### Any background context you want to provide?

When a user accepted a bid, the *bid* was marked as accepted, but the project did not move from "Open projects" to "Accepted projects" on the user dashboard. It didn't move because the *project* status wasn't being updated. I moved the update bid methods into their own PORO since they were now effecting both bids and projects at the same time.
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? no
  - Do Environment Variables need to be set? no
  - Any other deploy steps? no
